### PR TITLE
remove support for python2.7, requires 3.7+

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,11 +49,11 @@ jobs:
         arch: [auto64]
         build: ["*"]
         include:
-          # the manylinux1 docker images only contain from python3.6 to 3.9
+          # the manylinux1 docker images only contain from python3.7 to 3.9
           - os: ubuntu-latest
             type: manylinux1
             arch: auto
-            build: "cp{36,37,38,39}-*"
+            build: "cp{37,38,39}-*"
             CIBW_MANYLINUX_X86_64_IMAGE: manylinux1
             CIBW_MANYLINUX_I686_IMAGE: manylinux1
           # the manylinux2010 image also contains python 3.10
@@ -98,7 +98,7 @@ jobs:
     strategy:
       matrix:
         # aarch64 uses qemu so it's slow, build each py version in parallel jobs
-        python: [36, 37, 38, 39, 310]
+        python: [37, 38, 39, 310]
         arch: [aarch64]
     steps:
     - uses: actions/checkout@v2

--- a/README.rst
+++ b/README.rst
@@ -6,6 +6,8 @@ PYZOPFLI
 cPython bindings for
 `zopfli <http://googledevelopers.blogspot.com/2013/02/compress-data-more-densely-with-zopfli.html>`__.
 
+It requires Python 3.7 or greater.
+
 USAGE
 =====
 

--- a/setup.py
+++ b/setup.py
@@ -88,4 +88,5 @@ setup(
         "build_ext": custom_build_ext,
     },
     setup_requires=["setuptools_scm"],
+    python_requires=">=3.7",
 )

--- a/src/zopfli/gzip.py
+++ b/src/zopfli/gzip.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import zopfli
 import zopfli.zopfli
 

--- a/src/zopfli/zlib.py
+++ b/src/zopfli/zlib.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import zopfli
 import zopfli.zopfli
 

--- a/src/zopflimodule.c
+++ b/src/zopflimodule.c
@@ -10,11 +10,6 @@
 #endif
 #include ZOPFLI_H
 
-#if PY_MAJOR_VERSION >= 3
-#define PyInt_Check PyLong_Check
-#define PyInt_AsLong PyLong_AsLong
-#endif
-
 static PyObject *
 zopfli_compress(PyObject *self, PyObject *args, PyObject *keywrds)
 {
@@ -83,7 +78,6 @@ static PyMethodDef ZopfliMethods[] = {
 PyDoc_STRVAR(zopfli__doc__,
 "Wrapper around zopfli's ZlibCompress and GzipCompress methods.");
 
-#if PY_MAJOR_VERSION >= 3
 #define INIT_ZOPFLI   PyInit_zopfli
 #define CREATE_ZOPFLI PyModule_Create(&zopfli_module)
 #define RETURN_ZOPFLI return m
@@ -98,11 +92,6 @@ static struct PyModuleDef zopfli_module = {
   NULL,
   NULL
 };
-#else
-#define INIT_ZOPFLI   initzopfli
-#define CREATE_ZOPFLI Py_InitModule3("zopfli", ZopfliMethods, zopfli__doc__)
-#define RETURN_ZOPFLI return
-#endif
 
 PyMODINIT_FUNC INIT_ZOPFLI(void) {
   PyObject *m = CREATE_ZOPFLI;

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py36
+envlist = py3{7,8,9,10}
 
 [testenv]
 # pass-through all environment variables when building wheel on Windows


### PR DESCRIPTION
this will make it easier to add new features, like support for ZopfliPNGOptimize (which I am working on a separate WIP branch)
I decided to require 3.7 since 3.6 reached end-of-life at the end of last year.